### PR TITLE
Add `latest` tag for main branch builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/ls1intum/theia/operator
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push (multi-arch)
         uses: docker/build-push-action@v6
@@ -79,6 +83,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/ls1intum/theia/service
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push (multi-arch)
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Add `latest` tag for main branch builds

This PR adds automatic tagging of Docker images with `latest` when building from the `main` branch. Additionally, PR builds now receive proper tags for testing purposes.

### Changes
- Add `latest` tag to operator and service images when building from `main` branch
- Add PR tag support for pull request builds

### Motivation
Production environments currently use the `latest` tag (default behavior), but since this tag wasn't being created automatically, no recent updates were being picked up in production deployments. With this change, every push to `main` will update the `latest` tag, ensuring production environments receive the latest changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker image builds now include enhanced tagging configuration. Images are tagged with branch names, pull request numbers, and an automatic 'latest' tag when built from the main branch. This improvement makes it easier to track versions and identify specific builds for deployment across development stages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->