### PR TITLE
Refactor configuration to remove deprecated appId property and update…

### DIFF
--- a/node/common/src/config.ts
+++ b/node/common/src/config.ts
@@ -17,10 +17,6 @@ export namespace TheiaCloudConfig {
     if ('serviceAuthToken' in config && config.serviceAuthToken) {
       return config.serviceAuthToken;
     }
-    if ('appId' in config && config.appId) {
-      console.warn("Using deprecated property 'appId'. Please migrate to 'serviceAuthToken' in your configuration.");
-      return config.appId;
-    }
     throw new Error('Neither serviceAuthToken nor appId found in configuration');
   }
 }
@@ -44,10 +40,8 @@ interface BaseTheiaCloudConfig {
   useEphemeralStorage: boolean;
 }
 export interface AppDefinition {
-  /** @deprecated Use ServiceConfig#serviceAuthToken instead */
-  appId: string;
+  serviceAuthToken: string
   appName: string;
-  logo: string | undefined;
 }
 
 export interface ServiceConfig {
@@ -91,7 +85,7 @@ export interface LandingPageConfig {
 
 export type TheiaCloudConfig = (
   | (AppDefinition & Partial<ServiceConfig>)
-  | (Pick<AppDefinition, 'appName'> & ServiceConfig)
+  | (AppDefinition & ServiceConfig)
 ) &
   BaseTheiaCloudConfig &
   Partial<KeycloakConfig> &

--- a/node/landing-page/src/App.tsx
+++ b/node/landing-page/src/App.tsx
@@ -121,10 +121,10 @@ function App(): JSX.Element {
         if (config.additionalApps && config.additionalApps.length > 0) {
           // Find the selected app definition in the additional apps
           const appDefinition = config.additionalApps.find(
-            (appDef: AppDefinition) => appDef.appId === pathBlueprintSelection
+            appDef => appDef.serviceAuthToken === pathBlueprintSelection
           );
           setSelectedAppName(appDefinition ? appDefinition.appName : pathBlueprintSelection);
-          setSelectedAppDefinition(appDefinition ? appDefinition.appId : pathBlueprintSelection);
+          setSelectedAppDefinition(appDefinition ? appDefinition.serviceAuthToken : pathBlueprintSelection);
         } else {
           // If there are no additional apps, just use the application id as the name
           console.log('App definitition provided via URL parameter not found in additional apps');
@@ -499,7 +499,7 @@ function isDefaultSelectionValueValid(
     return true;
   }
   if (additionalApps && additionalApps.length > 0) {
-    return additionalApps.map(def => def.appId).filter(appId => appId === defaultSelection).length > 0;
+    return additionalApps.map(def => def.serviceAuthToken).filter(serviceAuthToken => serviceAuthToken === defaultSelection).length > 0;
   }
   // If there are no additional apps explicitly configured, we accept any app definition given via url parameter
   return true;

--- a/node/landing-page/src/components/SelectApp.tsx
+++ b/node/landing-page/src/components/SelectApp.tsx
@@ -11,8 +11,8 @@ export const SelectApp: React.FC<SelectAppProps> = ({ appDefinitions, onStartSes
           <button
             key={index}
             className='App__grid-item'
-            onClick={() => onStartSession(app.appId)}
-            data-testid={`launch-app-${app.appId}`}
+            onClick={() => onStartSession(app.serviceAuthToken)}
+            data-testid={`launch-app-${app.serviceAuthToken}`}
           >
             <img
               src={`/assets/logos/${app.appName.toLowerCase().replace(/\s+/g, '-')}-logo.png`}


### PR DESCRIPTION
… references to serviceAuthToken across the application. This includes changes in config.ts, App.tsx, and SelectApp.tsx to ensure consistent usage of the new property.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Application definitions no longer support appId or logo fields; serviceAuthToken is now required for app identification.
  * App selection mechanism updated to use serviceAuthToken instead of appId for matching and validation.

* **Configuration Updates**
  * Streamlined configuration structure with simplified app definition requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->