### PR TITLE
ci: Switch to self-hosted ARC runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,90 +24,26 @@ jobs:
       build-arm64: false
     secrets: inherit
 
-  # Operator and Service require Docker build secrets (SENTRY_AUTH_TOKEN)
-  # which the reusable workflow doesn't support, so we build them directly
   build-and-push-operator:
-    runs-on: arc-runner-set-stateless
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-
-      - uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/ls1intum/theia/operator
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: dockerfiles/operator/Dockerfile
-          push: true
-          platforms: linux/amd64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          secrets: |
-            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@feature/arc-runner-support
+    with:
+      docker-file: dockerfiles/operator/Dockerfile
+      image-name: ghcr.io/ls1intum/theia/operator
+      docker-context: .
+      runner-amd64: "arc-runner-set-stateless"
+      build-arm64: false
+      docker-secrets: |
+        SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+    secrets: inherit
 
   build-and-push-service:
-    runs-on: arc-runner-set-stateless
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-
-      - uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/ls1intum/theia/service
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: dockerfiles/service/Dockerfile
-          push: true
-          platforms: linux/amd64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          secrets: |
-            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@feature/arc-runner-support
+    with:
+      docker-file: dockerfiles/service/Dockerfile
+      image-name: ghcr.io/ls1intum/theia/service
+      docker-context: .
+      runner-amd64: "arc-runner-set-stateless"
+      build-arm64: false
+      docker-secrets: |
+        SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Switch to self-hosted ARC runners for faster CI queue times
- Disable ARM builds until ARM cluster is available
- Add concurrency control to prevent resource waste

## Changes

### Self-Hosted Runners
All jobs now use `arc-runner-set-stateless` instead of `ubuntu-latest`:
- Eliminates 10-20 minute queue times from GitHub-hosted runner contention
- Uses our dedicated ARC infrastructure in the theia-prod cluster

### ARM Builds Disabled
```yaml
build-arm64: false
```
ARM builds are temporarily disabled until the ARM cluster is operational.

### Concurrency Control
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
  cancel-in-progress: true
```

| Scenario | Result |
|----------|--------|
| PR from `feature/foo` | Independent |
| PR from `feature/bar` | Independent |
| 2nd push to `feature/foo` | **Cancels 1st run** |

### Workflow Simplification
Refactored operator and service jobs to use the reusable workflow from `ls1intum/.github`, reducing duplication and ensuring consistent build behavior across all images.

## Dependencies
- Requires `ls1intum/.github` PR [#37](https://github.com/ls1intum/.github/pull/37) for `feature/arc-runner-support` branch

## Images Affected
- `ghcr.io/ls1intum/theia/landing-page`
- `ghcr.io/ls1intum/theia/operator`
- `ghcr.io/ls1intum/theia/service`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build system architecture to streamline deployment processes across services.
  * Implemented improved workflow concurrency management to prevent conflicting simultaneous builds.
  * Updated build runner configuration for enhanced efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->