### PR TITLE
feat: Add commit SHA suffix to image tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,32 +14,84 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Determine base tag (pr-<nr> or latest) and SHA-suffixed tag
+  determine-tag:
+    runs-on: arc-runner-set-stateless
+    outputs:
+      base_tag: ${{ steps.set-tag.outputs.base_tag }}
+      sha_tag: ${{ steps.set-tag.outputs.sha_tag }}
+      cache_tag: ${{ steps.set-tag.outputs.cache_tag }}
+    steps:
+      - name: Checkout for SHA access
+        uses: actions/checkout@v4
+
+      - name: Set tags
+        id: set-tag
+        run: |
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE_TAG="pr-${{ github.event.pull_request.number }}"
+            CACHE_TAG="build-cache-pr-${{ github.event.pull_request.number }}"
+          else
+            BASE_TAG="latest"
+            CACHE_TAG="build-cache"
+          fi
+          
+          echo "base_tag=${BASE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "sha_tag=${BASE_TAG}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "cache_tag=${CACHE_TAG}" >> "$GITHUB_OUTPUT"
+
   build-and-push-landing-page:
+    needs: determine-tag
     uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@feature/arc-runner-support
     with:
       docker-file: dockerfiles/landing-page/Dockerfile
       image-name: ghcr.io/ls1intum/theia/landing-page
       docker-context: .
+      tags: |
+        ${{ needs.determine-tag.outputs.base_tag }}
+        ${{ needs.determine-tag.outputs.sha_tag }}
       runner-amd64: "arc-runner-set-stateless"
       build-arm64: false
+      cache-from: |
+        type=registry,ref=ghcr.io/ls1intum/theia/landing-page:${{ needs.determine-tag.outputs.cache_tag }}
+        type=registry,ref=ghcr.io/ls1intum/theia/landing-page:build-cache
+      cache-to: "type=registry,ref=ghcr.io/ls1intum/theia/landing-page:${{ needs.determine-tag.outputs.cache_tag }},mode=max"
     secrets: inherit
 
   build-and-push-operator:
+    needs: determine-tag
     uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@feature/arc-runner-support
     with:
       docker-file: dockerfiles/operator/Dockerfile
       image-name: ghcr.io/ls1intum/theia/operator
       docker-context: .
+      tags: |
+        ${{ needs.determine-tag.outputs.base_tag }}
+        ${{ needs.determine-tag.outputs.sha_tag }}
       runner-amd64: "arc-runner-set-stateless"
       build-arm64: false
+      cache-from: |
+        type=registry,ref=ghcr.io/ls1intum/theia/operator:${{ needs.determine-tag.outputs.cache_tag }}
+        type=registry,ref=ghcr.io/ls1intum/theia/operator:build-cache
+      cache-to: "type=registry,ref=ghcr.io/ls1intum/theia/operator:${{ needs.determine-tag.outputs.cache_tag }},mode=max"
     secrets: inherit
 
   build-and-push-service:
+    needs: determine-tag
     uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@feature/arc-runner-support
     with:
       docker-file: dockerfiles/service/Dockerfile
       image-name: ghcr.io/ls1intum/theia/service
       docker-context: .
+      tags: |
+        ${{ needs.determine-tag.outputs.base_tag }}
+        ${{ needs.determine-tag.outputs.sha_tag }}
       runner-amd64: "arc-runner-set-stateless"
       build-arm64: false
+      cache-from: |
+        type=registry,ref=ghcr.io/ls1intum/theia/service:${{ needs.determine-tag.outputs.cache_tag }}
+        type=registry,ref=ghcr.io/ls1intum/theia/service:build-cache
+      cache-to: "type=registry,ref=ghcr.io/ls1intum/theia/service:${{ needs.determine-tag.outputs.cache_tag }},mode=max"
     secrets: inherit


### PR DESCRIPTION
## Summary
This PR adds commit SHA suffixes to Docker image tags, enabling precise version identification and deployment rollback capabilities.

## Changes
- Added `determine-tag` job to compute tags based on event type
- Images now receive **two tags**:
  - Base tag: `pr-<number>` for PRs, `latest` for main
  - SHA tag: `pr-<number>-a1b2c3d` or `latest-a1b2c3d`
- Added registry-based caching with PR-specific cache tags
- All 3 images (landing-page, operator, service) now use the unified tagging strategy

## Benefits
- **Traceability**: Every image can be traced to exact commit
- **Rollback**: Deploy specific versions by SHA tag
- **Caching**: PR builds use dedicated cache, avoiding cache pollution

## Example Tags
| Event | Base Tag | SHA Tag |
|-------|----------|---------|
| PR #62 | `pr-62` | `pr-62-a1b2c3d` |
| Push to main | `latest` | `latest-a1b2c3d` |

## Dependencies
- Requires ls1intum/.github#37 (`feature/arc-runner-support`) for `tags` input support
- Builds on #62 (`feature/self-hosted-runners`) for ARC runner configuration

## Related
- Follows same pattern as ls1intum/artemis-theia-blueprints#73