### PR TITLE
chore: Improve .gitignore to exclude IDE and build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,20 @@
 .openapi-generator
 .openapi-generator-ignore
 openapitools.json
+
+# IDE files
+.classpath
+.project
+.settings/
+.factorypath
+*.iml
+.idea/
+.vscode/
+
+# OS files
 .DS_Store
 
+# Build artifacts
+target/
 node_modules
 node/e2e-tests/test-results/.last-run.json


### PR DESCRIPTION
## Summary
- Adds comprehensive IDE file exclusions to prevent Eclipse, IntelliJ, and VS Code configuration files from appearing as untracked
- Adds build artifact exclusions (target/)
- Organizes .gitignore with clear sections for better maintainability

## Changes
- **IDE files**: `.classpath`, `.project`, `.settings/`, `.factorypath`, `*.iml`, `.idea/`, `.vscode/`
- **OS files**: `.DS_Store` (moved to dedicated section)
- **Build artifacts**: `target/`, `node_modules`

## Motivation
Eclipse IDE files were repeatedly appearing as untracked files after building Java components. This change prevents IDE-specific configuration from polluting git status.

## Testing
- ✅ Verified .gitignore syntax
- ✅ Confirmed existing patterns still work
- ✅ No breaking changes to tracked files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to exclude additional development tool and build files from version control.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->