### PR TITLE
feat: Add support for versioned releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
   release:
+    types:
+      - published
+      - prereleased
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
Adds automatic Docker image tagging when GitHub releases are published, enabling proper version management.

## Motivation
Currently, theia-cloud releases don't trigger Docker image builds. When you publish a release (e.g., v1.1.2), no corresponding Docker images are created with that version tag. This makes it difficult to:
- Pin deployments to specific release versions
- Track which version is running in production
- Roll back to previous release versions

## Changes

### 1. Added `release` event trigger
```yaml
on:
  release:  # New!
```

### 2. Updated tag determination logic
Added handling for release events in the `determine-tag` job:
```yaml
elif [[ "${{ github.event_name }}" == "release" ]]; then
  # For release events, use the release tag/version
  BASE_TAG="${{ github.event.release.tag_name }}"
  CACHE_TAG="build-cache-release"
```

## Result

When you publish a release `v1.1.2`, the workflow will automatically build and tag all three images:

**Landing Page:**
- `ghcr.io/ls1intum/theia/landing-page:v1.1.2`
- `ghcr.io/ls1intum/theia/landing-page:v1.1.2-<sha>`

**Operator:**
- `ghcr.io/ls1intum/theia/operator:v1.1.2`
- `ghcr.io/ls1intum/theia/operator:v1.1.2-<sha>`

**Service:**
- `ghcr.io/ls1intum/theia/service:v1.1.2`
- `ghcr.io/ls1intum/theia/service:v1.1.2-<sha>`

**Existing behavior remains completely unchanged:**
- Pull requests → `pr-<number>` tags
- Pushes to main → `latest` tag
- Workflow dispatch → branch name tags

## Testing
After merging, publish a test release (e.g., `v1.2.0-test`) to verify the workflow generates the expected tags.

## Related
Fixes the issue where releases were published but no corresponding Docker images were available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD workflow updated to explicitly handle release events, enabling automated builds to run for releases.
  * Tag-determination and cache-tag logic refined so release builds use the release tag and a release-specific cache identifier, while existing branch and PR behaviors are preserved for other events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->