### PR TITLE
fix(operator): preserve eager auth email allowlist during reconcile

### DIFF
--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/pool/PrewarmedResourcePool.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/pool/PrewarmedResourcePool.java
@@ -295,6 +295,7 @@ public class PrewarmedResourcePool {
             String ownerName = appDef.getMetadata().getName();
             String ownerUID = appDef.getMetadata().getUid();
             OwnerContext owner = OwnerContext.of(ownerName, ownerUID, AppDefinition.API, AppDefinition.KIND);
+            long currentGeneration = appDef.getMetadata().getGeneration();
             Map<String, String> labels = new HashMap<>();
 
             boolean success = true;
@@ -324,7 +325,10 @@ public class PrewarmedResourcePool {
                             .idExtractor(s -> TheiaCloudServiceUtil.getId(correlationId, appDef, s))
                             .resourceTypeName("service").createResource(instance -> {
                                 resourceFactory.createServiceForEagerInstance(appDef, instance, labels, correlationId);
-                            }).shouldRecreate(s -> OwnershipManager.isOwnedSolelyBy(s, owner)).recreateResource(s -> {
+                            }).shouldRecreate(
+                                    s -> OwnershipManager.isOwnedSolelyBy(s, owner)
+                                            && isOutdated(s, currentGeneration))
+                            .recreateResource(s -> {
                                 Integer id = TheiaCloudServiceUtil.getId(correlationId, appDef, s);
                                 if (id != null) {
                                     resourceFactory.createServiceForEagerInstance(appDef, id, labels, correlationId);
@@ -343,7 +347,10 @@ public class PrewarmedResourcePool {
                             .resourceTypeName("internal service").createResource(instance -> {
                                 resourceFactory.createInternalServiceForEagerInstance(appDef, instance, labels,
                                         correlationId);
-                            }).shouldRecreate(s -> OwnershipManager.isOwnedSolelyBy(s, owner)).recreateResource(s -> {
+                            }).shouldRecreate(
+                                    s -> OwnershipManager.isOwnedSolelyBy(s, owner)
+                                            && isOutdated(s, currentGeneration))
+                            .recreateResource(s -> {
                                 Integer id = TheiaCloudServiceUtil.getId(correlationId, appDef, s);
                                 if (id != null) {
                                     resourceFactory.createInternalServiceForEagerInstance(appDef, id, labels,
@@ -392,7 +399,8 @@ public class PrewarmedResourcePool {
                                 .resourceTypeName("proxy configmap")
                                 .createResource(instance -> resourceFactory.createProxyConfigMapForEagerInstance(appDef,
                                         instance, labels, correlationId))
-                                .shouldRecreate(cm -> OwnershipManager.isOwnedSolelyBy(cm, owner))
+                                .shouldRecreate(cm -> OwnershipManager.isOwnedSolelyBy(cm, owner)
+                                        && isOutdated(cm, currentGeneration))
                                 .recreateResource(cm -> {
                                     Integer id = TheiaCloudConfigMapUtil.getProxyId(correlationId, appDef, cm);
                                     if (id != null) {
@@ -412,7 +420,8 @@ public class PrewarmedResourcePool {
                                 .resourceTypeName("email configmap")
                                 .createResource(instance -> resourceFactory.createEmailConfigMapForEagerInstance(appDef,
                                         instance, labels, correlationId))
-                                .shouldRecreate(cm -> OwnershipManager.isOwnedSolelyBy(cm, owner))
+                                .shouldRecreate(cm -> OwnershipManager.isOwnedSolelyBy(cm, owner)
+                                        && isOutdated(cm, currentGeneration))
                                 .recreateResource(cm -> {
                                     Integer id = TheiaCloudConfigMapUtil.getEmailId(correlationId, appDef, cm);
                                     if (id != null) {
@@ -456,7 +465,10 @@ public class PrewarmedResourcePool {
                             .resourceTypeName("deployment")
                             .createResource(instance -> resourceFactory.createDeploymentForEagerInstance(appDef,
                                     instance, labels, correlationId))
-                            .shouldRecreate(d -> OwnershipManager.isOwnedSolelyBy(d, owner)).recreateResource(d -> {
+                            .shouldRecreate(
+                                    d -> OwnershipManager.isOwnedSolelyBy(d, owner)
+                                            && isOutdated(d, currentGeneration))
+                            .recreateResource(d -> {
                                 Integer id = TheiaCloudDeploymentUtil.getId(correlationId, appDef, d);
                                 if (id != null) {
                                     resourceFactory.createDeploymentForEagerInstance(appDef, id, labels, correlationId);
@@ -569,24 +581,28 @@ public class PrewarmedResourcePool {
 
     private boolean isOutdated(List<? extends HasMetadata> resources, long currentGeneration) {
         for (var resource : resources) {
-            Map<String, String> labels = resource.getMetadata().getLabels();
-            if (labels == null) {
-                return true;
-            }
-            String genLabel = labels.get(APPDEFINITION_GENERATION_LABEL);
-            if (genLabel == null) {
-                return true;
-            }
-            try {
-                long resourceGen = Long.parseLong(genLabel);
-                if (resourceGen != currentGeneration) {
-                    return true;
-                }
-            } catch (NumberFormatException e) {
+            if (isOutdated(resource, currentGeneration)) {
                 return true;
             }
         }
         return false;
+    }
+
+    private boolean isOutdated(HasMetadata resource, long currentGeneration) {
+        Map<String, String> labels = resource.getMetadata().getLabels();
+        if (labels == null) {
+            return true;
+        }
+        String genLabel = labels.get(APPDEFINITION_GENERATION_LABEL);
+        if (genLabel == null) {
+            return true;
+        }
+        try {
+            long resourceGen = Long.parseLong(genLabel);
+            return resourceGen != currentGeneration;
+        } catch (NumberFormatException e) {
+            return true;
+        }
     }
 
     private void deleteInstanceResources(List<Service> services, List<Deployment> deployments,


### PR DESCRIPTION
## Summary
Fixes eager session re-authentication failures caused by pool reconciliation recreating eager resources (especially email allowlist ConfigMaps) even when they were not outdated.

## Problem
Eager sessions could fail authentication after some time although the session remained valid.

Observed behavior:
- oauth2-proxy reported invalid email / auth failures
- eager email ConfigMap `authenticated-emails-list` was reset to empty
- issue did not reproduce for lazy sessions

## Root Cause
`PrewarmedResourcePool.reconcile()` used `OwnershipManager.isOwnedSolelyBy(...)` as recreation criterion.

That allowed reconcile to recreate eager resources that were solely AppDefinition-owned, including email ConfigMaps, which reset user-specific allowlists.

## Solution
Restrict resource recreation during reconcile to resources that are both:
- solely owned by the AppDefinition, and
- outdated by `theia-cloud.io/appdefinition-generation`

This preserves active eager session bindings unless a real generation update requires recreation.

## Files Changed
- `java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/pool/PrewarmedResourcePool.java`

## Verification
- `mvn -q -DskipTests compile` in `java/operator/org.eclipse.theia.cloud.operator`
- manual cluster investigation in `theia-staging` confirmed previous reset pattern and oauth2-proxy invalid-email failures

## Risk Assessment
Low to medium.

Behavior change is scoped to reconcile recreation criteria. Resource creation/deletion paths remain unchanged.

## Rollout Notes
After deploying the operator update:
1. Validate that eager session reopen after idle time still authenticates successfully.
2. Confirm eager email ConfigMaps are not recreated/reset during normal reconcile/restart.
3. Verify recreation still happens when AppDefinition generation changes.
