### PR TITLE
Add auto-assign PR author workflow

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,23 @@
+name: Auto Assign PR Author
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Auto assign PR author
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: [context.payload.pull_request.user.login]
+            });
+


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/auto-assign.yml` to automatically assign the PR author as assignee
- Triggers on PR open, reopen, and ready-for-review events
- Uses `actions/github-script` with the GitHub API to set the assignee

## Test plan
- [ ] Open a new PR and verify the author is auto-assigned