### PR TITLE
Fix temurin builder base tag for cloud images

### DIFF
--- a/dockerfiles/conversion-webhook/Dockerfile
+++ b/dockerfiles/conversion-webhook/Dockerfile
@@ -23,7 +23,7 @@ RUN --mount=type=cache,target=/root/.m2 \
     cd /conversion/conversion/org.eclipse.theia.cloud.conversion && \
     mvn clean package -Dmaven.test.skip=true -Dquarkus.package.type=uber-jar --no-transfer-progress
 
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:21-jre-alpine@sha256:6ad8ed080d9be96b61438ec3ce99388e294af216ed57356000c06070e85c5d5d
 WORKDIR /conversion
 COPY --from=builder /conversion/conversion/org.eclipse.theia.cloud.conversion/target/conversion-webhook-1.2.0-SNAPSHOT-runner.jar .
 

--- a/dockerfiles/operator/Dockerfile
+++ b/dockerfiles/operator/Dockerfile
@@ -35,7 +35,7 @@ RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN \
     cd /operator/operator/org.eclipse.theia.cloud.defaultoperator && \
     mvn clean verify --no-transfer-progress $MAVEN_SENTRY_ARGS
 
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:21-jre-alpine@sha256:6ad8ed080d9be96b61438ec3ce99388e294af216ed57356000c06070e85c5d5d
 RUN apk add --no-cache curl unzip
 RUN mkdir /templates
 WORKDIR /log-config

--- a/dockerfiles/service/Dockerfile
+++ b/dockerfiles/service/Dockerfile
@@ -33,7 +33,7 @@ RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN \
     cd /service/service/org.eclipse.theia.cloud.service && \
     mvn clean package -Dmaven.test.skip=true -Dquarkus.package.type=uber-jar --no-transfer-progress $MAVEN_SENTRY_ARGS
 
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:21-jre-alpine@sha256:6ad8ed080d9be96b61438ec3ce99388e294af216ed57356000c06070e85c5d5d
 RUN apk add --no-cache curl unzip
 WORKDIR /service
 RUN curl -fsSL -o sentry-agent.zip https://github.com/getsentry/sentry-java/releases/download/8.29.0/sentry-opentelemetry-agent-8.29.0.zip && \


### PR DESCRIPTION
## Summary
- switch builder base image in cloud Dockerfiles from `eclipse-temurin:21-jdk` to `eclipse-temurin:21-jdk-jammy`
- apply change to conversion-webhook, operator, and service Dockerfiles
- avoids current Zot sync/commit failure path seen for `21-jdk` while keeping Java 21 JDK builder semantics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned build and runtime base images for multiple components to immutable image digests, improving build reproducibility and runtime consistency across releases and reducing variability from floating tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->