### PR TITLE
Use release tag for Docker image tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
       docker-file: dockerfiles/operator/Dockerfile
       image-name: eduide/eduide-cloud/operator
       docker-context: .
-      image-tag: ${{ github.event_name == 'workflow_dispatch' && inputs.image_tag || '' }}
+      image-tag: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event_name == 'workflow_dispatch' && inputs.image_tag || '' }}
       execution-mode: ${{ github.event_name == 'workflow_dispatch' && inputs.execution_mode || 'self-hosted-buildkit' }}
       arc-registry-cache: ${{ github.event_name == 'workflow_dispatch' && inputs.arc_registry_cache || false }}
       no-cache: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.disable_layer_cache) || false }}
@@ -77,7 +77,7 @@ jobs:
       docker-file: dockerfiles/service/Dockerfile
       image-name: eduide/eduide-cloud/service
       docker-context: .
-      image-tag: ${{ github.event_name == 'workflow_dispatch' && inputs.image_tag || '' }}
+      image-tag: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event_name == 'workflow_dispatch' && inputs.image_tag || '' }}
       execution-mode: ${{ github.event_name == 'workflow_dispatch' && inputs.execution_mode || 'self-hosted-buildkit' }}
       arc-registry-cache: ${{ github.event_name == 'workflow_dispatch' && inputs.arc_registry_cache || false }}
       no-cache: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.disable_layer_cache) || false }}
@@ -95,7 +95,7 @@ jobs:
       docker-file: dockerfiles/conversion-webhook/Dockerfile
       image-name: eduide/eduide-cloud/conversion-webhook
       docker-context: .
-      image-tag: ${{ github.event_name == 'workflow_dispatch' && inputs.image_tag || '' }}
+      image-tag: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event_name == 'workflow_dispatch' && inputs.image_tag || '' }}
       execution-mode: ${{ github.event_name == 'workflow_dispatch' && inputs.execution_mode || 'self-hosted-buildkit' }}
       arc-registry-cache: ${{ github.event_name == 'workflow_dispatch' && inputs.arc_registry_cache || false }}
       no-cache: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.disable_layer_cache) || false }}


### PR DESCRIPTION
Pass the GitHub release tag explicitly to the reusable Docker build workflow so release builds publish images with the exact Git tag instead of relying on fallback tag derivation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container image tagging to align with release versions for better version consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EduIDE/EduIDE-Cloud/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->