### PR TITLE
add bazel url, and remove tls setup

### DIFF
--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/TheiaCloudOperatorArguments.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/TheiaCloudOperatorArguments.java
@@ -134,8 +134,11 @@ public class TheiaCloudOperatorArguments {
             "--enableBuildCaching" }, description = "Whether to enable caching of Theia application builds.", required = false)
     private boolean enableBuildCaching = false;
 
-    @Option(names = { "--buildCacheUrl" }, description = "The URL of the remote build cache server.", required = false)
-    private String buildCacheUrl;
+    @Option(names = { "--gradleBuildCacheUrl" }, description = "The URL of the remote Gradle build cache server.", required = false)
+    private String gradleBuildCacheUrl;
+
+    @Option(names = { "--bazelBuildCacheUrl" }, description = "The URL of the remote Bazel build cache server.", required = false)
+    private String bazelBuildCacheUrl;
 
     @Option(names = {
             "--enableBuildCachePush" }, description = "Whether sessions are allowed to push to the build cache.", required = false)
@@ -304,9 +307,11 @@ public class TheiaCloudOperatorArguments {
      * @throws IllegalArgumentException if a caching flag is enabled but its URL is missing
      */
     public void validate() {
-        if (enableBuildCaching && (buildCacheUrl == null || buildCacheUrl.trim().isEmpty())) {
+        if (enableBuildCaching
+                && (gradleBuildCacheUrl == null || gradleBuildCacheUrl.trim().isEmpty())
+                && (bazelBuildCacheUrl == null || bazelBuildCacheUrl.trim().isEmpty())) {
             throw new IllegalArgumentException(
-                    "--buildCacheUrl is required when --enableBuildCaching is set");
+                    "At least one of --gradleBuildCacheUrl or --bazelBuildCacheUrl is required when --enableBuildCaching is set");
         }
         if (enableDependencyCaching && (dependencyCacheUrl == null || dependencyCacheUrl.trim().isEmpty())) {
             throw new IllegalArgumentException(
@@ -318,8 +323,12 @@ public class TheiaCloudOperatorArguments {
         return enableBuildCaching;
     }
 
-    public String getBuildCacheUrl() {
-        return buildCacheUrl;
+    public String getGradleBuildCacheUrl() {
+        return gradleBuildCacheUrl;
+    }
+
+    public String getBazelBuildCacheUrl() {
+        return bazelBuildCacheUrl;
     }
 
     public boolean isEnableBuildCachePush() {
@@ -366,7 +375,8 @@ public class TheiaCloudOperatorArguments {
         result = prime * result + ((wondershaperImage == null) ? 0 : wondershaperImage.hashCode());
         result = prime * result + ((oAuth2ProxyVersion == null) ? 0 : oAuth2ProxyVersion.hashCode());
         result = prime * result + (enableBuildCaching ? 1231 : 1237);
-        result = prime * result + ((buildCacheUrl == null) ? 0 : buildCacheUrl.hashCode());
+        result = prime * result + ((gradleBuildCacheUrl == null) ? 0 : gradleBuildCacheUrl.hashCode());
+        result = prime * result + ((bazelBuildCacheUrl == null) ? 0 : bazelBuildCacheUrl.hashCode());
         result = prime * result + (enableBuildCachePush ? 1231 : 1237);
         result = prime * result + (enableDependencyCaching ? 1231 : 1237);
         result = prime * result + ((dependencyCacheUrl == null) ? 0 : dependencyCacheUrl.hashCode());
@@ -483,10 +493,15 @@ public class TheiaCloudOperatorArguments {
             return false;
         if (enableBuildCaching != other.enableBuildCaching)
             return false;
-        if (buildCacheUrl == null) {
-            if (other.buildCacheUrl != null)
+        if (gradleBuildCacheUrl == null) {
+            if (other.gradleBuildCacheUrl != null)
                 return false;
-        } else if (!buildCacheUrl.equals(other.buildCacheUrl))
+        } else if (!gradleBuildCacheUrl.equals(other.gradleBuildCacheUrl))
+            return false;
+        if (bazelBuildCacheUrl == null) {
+            if (other.bazelBuildCacheUrl != null)
+                return false;
+        } else if (!bazelBuildCacheUrl.equals(other.bazelBuildCacheUrl))
             return false;
         if (enableBuildCachePush != other.enableBuildCachePush)
             return false;
@@ -513,8 +528,9 @@ public class TheiaCloudOperatorArguments {
                 + ", keycloakClientId=" + keycloakClientId + ", leaderLeaseDuration=" + leaderLeaseDuration
                 + ", leaderRenewDeadline=" + leaderRenewDeadline + ", leaderRetryPeriod=" + leaderRetryPeriod
                 + ", maxWatchIdleTime=" + maxWatchIdleTime + ", continueOnException=" + continueOnException
-                + ", oAuth2ProxyVersion=" + oAuth2ProxyVersion + ", enableBuildCaching=" + enableBuildCaching + ", buildCacheUrl="
-                + buildCacheUrl + ", enableBuildCachePush=" + enableBuildCachePush
+                + ", oAuth2ProxyVersion=" + oAuth2ProxyVersion + ", enableBuildCaching=" + enableBuildCaching
+                + ", gradleBuildCacheUrl=" + gradleBuildCacheUrl + ", bazelBuildCacheUrl=" + bazelBuildCacheUrl
+                + ", enableBuildCachePush=" + enableBuildCachePush
                 + ", enableDependencyCaching=" + enableDependencyCaching + ", dependencyCacheUrl="
                 + dependencyCacheUrl + "]";
     }

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/TheiaCloudOperatorArguments.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/TheiaCloudOperatorArguments.java
@@ -134,8 +134,8 @@ public class TheiaCloudOperatorArguments {
             "--enableBuildCaching" }, description = "Whether to enable caching of Theia application builds.", required = false)
     private boolean enableBuildCaching = false;
 
-    @Option(names = { "--gradleBuildCacheUrl" }, description = "The URL of the remote Gradle build cache server.", required = false)
-    private String gradleBuildCacheUrl;
+    @Option(names = { "--buildCacheUrl", "--gradleBuildCacheUrl" }, description = "The URL of the remote Gradle build cache server.", required = false)
+    private String buildCacheUrl;
 
     @Option(names = { "--bazelBuildCacheUrl" }, description = "The URL of the remote Bazel build cache server.", required = false)
     private String bazelBuildCacheUrl;
@@ -308,10 +308,10 @@ public class TheiaCloudOperatorArguments {
      */
     public void validate() {
         if (enableBuildCaching
-                && (gradleBuildCacheUrl == null || gradleBuildCacheUrl.trim().isEmpty())
+                && (buildCacheUrl == null || buildCacheUrl.trim().isEmpty())
                 && (bazelBuildCacheUrl == null || bazelBuildCacheUrl.trim().isEmpty())) {
             throw new IllegalArgumentException(
-                    "At least one of --gradleBuildCacheUrl or --bazelBuildCacheUrl is required when --enableBuildCaching is set");
+                    "At least one of --buildCacheUrl or --bazelBuildCacheUrl is required when --enableBuildCaching is set");
         }
         if (enableDependencyCaching && (dependencyCacheUrl == null || dependencyCacheUrl.trim().isEmpty())) {
             throw new IllegalArgumentException(
@@ -323,8 +323,8 @@ public class TheiaCloudOperatorArguments {
         return enableBuildCaching;
     }
 
-    public String getGradleBuildCacheUrl() {
-        return gradleBuildCacheUrl;
+    public String getBuildCacheUrl() {
+        return buildCacheUrl;
     }
 
     public String getBazelBuildCacheUrl() {
@@ -375,7 +375,7 @@ public class TheiaCloudOperatorArguments {
         result = prime * result + ((wondershaperImage == null) ? 0 : wondershaperImage.hashCode());
         result = prime * result + ((oAuth2ProxyVersion == null) ? 0 : oAuth2ProxyVersion.hashCode());
         result = prime * result + (enableBuildCaching ? 1231 : 1237);
-        result = prime * result + ((gradleBuildCacheUrl == null) ? 0 : gradleBuildCacheUrl.hashCode());
+        result = prime * result + ((buildCacheUrl == null) ? 0 : buildCacheUrl.hashCode());
         result = prime * result + ((bazelBuildCacheUrl == null) ? 0 : bazelBuildCacheUrl.hashCode());
         result = prime * result + (enableBuildCachePush ? 1231 : 1237);
         result = prime * result + (enableDependencyCaching ? 1231 : 1237);
@@ -493,10 +493,10 @@ public class TheiaCloudOperatorArguments {
             return false;
         if (enableBuildCaching != other.enableBuildCaching)
             return false;
-        if (gradleBuildCacheUrl == null) {
-            if (other.gradleBuildCacheUrl != null)
+        if (buildCacheUrl == null) {
+            if (other.buildCacheUrl != null)
                 return false;
-        } else if (!gradleBuildCacheUrl.equals(other.gradleBuildCacheUrl))
+        } else if (!buildCacheUrl.equals(other.buildCacheUrl))
             return false;
         if (bazelBuildCacheUrl == null) {
             if (other.bazelBuildCacheUrl != null)
@@ -529,7 +529,7 @@ public class TheiaCloudOperatorArguments {
                 + ", leaderRenewDeadline=" + leaderRenewDeadline + ", leaderRetryPeriod=" + leaderRetryPeriod
                 + ", maxWatchIdleTime=" + maxWatchIdleTime + ", continueOnException=" + continueOnException
                 + ", oAuth2ProxyVersion=" + oAuth2ProxyVersion + ", enableBuildCaching=" + enableBuildCaching
-                + ", gradleBuildCacheUrl=" + gradleBuildCacheUrl + ", bazelBuildCacheUrl=" + bazelBuildCacheUrl
+                + ", buildCacheUrl=" + buildCacheUrl + ", bazelBuildCacheUrl=" + bazelBuildCacheUrl
                 + ", enableBuildCachePush=" + enableBuildCachePush
                 + ", enableDependencyCaching=" + enableDependencyCaching + ", dependencyCacheUrl="
                 + dependencyCacheUrl + "]";

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/replacements/DefaultDeploymentTemplateReplacements.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/replacements/DefaultDeploymentTemplateReplacements.java
@@ -69,14 +69,14 @@ public class DefaultDeploymentTemplateReplacements implements DeploymentTemplate
     public static final String PLACEHOLDER_OAUTH2_PROXY_VERSION = "placeholder-oauth2-proxy-version";
 
     public static final String PLACEHOLDER_ENV_BUILD_CACHE_ENABLED = "placeholder-build-cache-enabled";
-    public static final String PLACEHOLDER_ENV_GRADLE_BUILD_CACHE_URL = "placeholder-gradle-build-cache-url";
+    public static final String PLACEHOLDER_ENV_BUILD_CACHE_URL = "placeholder-build-cache-url";
     public static final String PLACEHOLDER_ENV_BAZEL_BUILD_CACHE_URL = "placeholder-bazel-build-cache-url";
     public static final String PLACEHOLDER_ENV_BUILD_CACHE_PUSH = "placeholder-build-cache-push";
 
     public static final String PLACEHOLDER_ENV_DEPENDENCY_CACHE_ENABLED = "placeholder-dependency-cache-enabled";
     public static final String PLACEHOLDER_ENV_DEPENDENCY_CACHE_URL = "placeholder-dependency-cache-url";
 
-protected static final String DEFAULT_UID = "1000";
+    protected static final String DEFAULT_UID = "1000";
 
     @Inject
     protected TheiaCloudOperatorArguments arguments;
@@ -158,22 +158,22 @@ protected static final String DEFAULT_UID = "1000";
             environmentVariables.put(PLACEHOLDER_ENV_SESSION_KEYCLOAK_CLIENT_ID, "");
         }
 
-        boolean gradleCacheActive = arguments.isEnableBuildCaching() && arguments.getGradleBuildCacheUrl() != null
-                && !arguments.getGradleBuildCacheUrl().trim().isEmpty();
+        boolean gradleCacheActive = arguments.isEnableBuildCaching() && arguments.getBuildCacheUrl() != null
+                && !arguments.getBuildCacheUrl().trim().isEmpty();
         boolean bazelCacheActive = arguments.isEnableBuildCaching() && arguments.getBazelBuildCacheUrl() != null
                 && !arguments.getBazelBuildCacheUrl().trim().isEmpty();
 
         if (gradleCacheActive || bazelCacheActive) {
             environmentVariables.put(PLACEHOLDER_ENV_BUILD_CACHE_ENABLED, "true");
-            environmentVariables.put(PLACEHOLDER_ENV_GRADLE_BUILD_CACHE_URL,
-                    gradleCacheActive ? arguments.getGradleBuildCacheUrl().trim() : "");
+            environmentVariables.put(PLACEHOLDER_ENV_BUILD_CACHE_URL,
+                    gradleCacheActive ? arguments.getBuildCacheUrl().trim() : "");
             environmentVariables.put(PLACEHOLDER_ENV_BAZEL_BUILD_CACHE_URL,
                     bazelCacheActive ? arguments.getBazelBuildCacheUrl().trim() : "");
             environmentVariables.put(PLACEHOLDER_ENV_BUILD_CACHE_PUSH,
                     arguments.isEnableBuildCachePush() ? "true" : "false");
         } else {
             environmentVariables.put(PLACEHOLDER_ENV_BUILD_CACHE_ENABLED, "false");
-            environmentVariables.put(PLACEHOLDER_ENV_GRADLE_BUILD_CACHE_URL, "");
+            environmentVariables.put(PLACEHOLDER_ENV_BUILD_CACHE_URL, "");
             environmentVariables.put(PLACEHOLDER_ENV_BAZEL_BUILD_CACHE_URL, "");
             environmentVariables.put(PLACEHOLDER_ENV_BUILD_CACHE_PUSH, "false");
         }

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/replacements/DefaultDeploymentTemplateReplacements.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/replacements/DefaultDeploymentTemplateReplacements.java
@@ -69,18 +69,14 @@ public class DefaultDeploymentTemplateReplacements implements DeploymentTemplate
     public static final String PLACEHOLDER_OAUTH2_PROXY_VERSION = "placeholder-oauth2-proxy-version";
 
     public static final String PLACEHOLDER_ENV_BUILD_CACHE_ENABLED = "placeholder-build-cache-enabled";
-    public static final String PLACEHOLDER_ENV_BUILD_CACHE_URL = "placeholder-build-cache-url";
+    public static final String PLACEHOLDER_ENV_GRADLE_BUILD_CACHE_URL = "placeholder-gradle-build-cache-url";
+    public static final String PLACEHOLDER_ENV_BAZEL_BUILD_CACHE_URL = "placeholder-bazel-build-cache-url";
     public static final String PLACEHOLDER_ENV_BUILD_CACHE_PUSH = "placeholder-build-cache-push";
 
     public static final String PLACEHOLDER_ENV_DEPENDENCY_CACHE_ENABLED = "placeholder-dependency-cache-enabled";
     public static final String PLACEHOLDER_ENV_DEPENDENCY_CACHE_URL = "placeholder-dependency-cache-url";
 
-    public static final String PLACEHOLDER_CA_BUNDLE_PEM_PATH = "placeholder-ca-bundle-pem-path";
-    public static final String PLACEHOLDER_GRADLE_TRUST_OPTS = "placeholder-gradle-trust-opts";
-    public static final String PLACEHOLDER_TRUST_BUNDLE_MOUNT_PATH = "placeholder-trust-bundle-mount-path";
-    public static final String PLACEHOLDER_TRUST_BUNDLE_CONFIGMAP = "placeholder-trust-bundle-configmap";
-
-    protected static final String DEFAULT_UID = "1000";
+protected static final String DEFAULT_UID = "1000";
 
     @Inject
     protected TheiaCloudOperatorArguments arguments;
@@ -162,15 +158,23 @@ public class DefaultDeploymentTemplateReplacements implements DeploymentTemplate
             environmentVariables.put(PLACEHOLDER_ENV_SESSION_KEYCLOAK_CLIENT_ID, "");
         }
 
-        if (arguments.isEnableBuildCaching() && arguments.getBuildCacheUrl() != null
-                && !arguments.getBuildCacheUrl().trim().isEmpty()) {
+        boolean gradleCacheActive = arguments.isEnableBuildCaching() && arguments.getGradleBuildCacheUrl() != null
+                && !arguments.getGradleBuildCacheUrl().trim().isEmpty();
+        boolean bazelCacheActive = arguments.isEnableBuildCaching() && arguments.getBazelBuildCacheUrl() != null
+                && !arguments.getBazelBuildCacheUrl().trim().isEmpty();
+
+        if (gradleCacheActive || bazelCacheActive) {
             environmentVariables.put(PLACEHOLDER_ENV_BUILD_CACHE_ENABLED, "true");
-            environmentVariables.put(PLACEHOLDER_ENV_BUILD_CACHE_URL, arguments.getBuildCacheUrl().trim());
+            environmentVariables.put(PLACEHOLDER_ENV_GRADLE_BUILD_CACHE_URL,
+                    gradleCacheActive ? arguments.getGradleBuildCacheUrl().trim() : "");
+            environmentVariables.put(PLACEHOLDER_ENV_BAZEL_BUILD_CACHE_URL,
+                    bazelCacheActive ? arguments.getBazelBuildCacheUrl().trim() : "");
             environmentVariables.put(PLACEHOLDER_ENV_BUILD_CACHE_PUSH,
                     arguments.isEnableBuildCachePush() ? "true" : "false");
         } else {
             environmentVariables.put(PLACEHOLDER_ENV_BUILD_CACHE_ENABLED, "false");
-            environmentVariables.put(PLACEHOLDER_ENV_BUILD_CACHE_URL, "");
+            environmentVariables.put(PLACEHOLDER_ENV_GRADLE_BUILD_CACHE_URL, "");
+            environmentVariables.put(PLACEHOLDER_ENV_BAZEL_BUILD_CACHE_URL, "");
             environmentVariables.put(PLACEHOLDER_ENV_BUILD_CACHE_PUSH, "false");
         }
 
@@ -182,21 +186,6 @@ public class DefaultDeploymentTemplateReplacements implements DeploymentTemplate
         } else {
             environmentVariables.put(PLACEHOLDER_ENV_DEPENDENCY_CACHE_ENABLED, "false");
             environmentVariables.put(PLACEHOLDER_ENV_DEPENDENCY_CACHE_URL, "");
-        }
-
-        if (arguments.isEnableBuildCaching() && arguments.getBuildCacheUrl() != null
-                && arguments.getBuildCacheUrl().trim().startsWith("https")) {
-            // Only set trust config when using HTTPS for the cache
-            environmentVariables.put(PLACEHOLDER_CA_BUNDLE_PEM_PATH, "/etc/ssl/theia-trust/trust-bundle.pem");
-            environmentVariables.put(PLACEHOLDER_GRADLE_TRUST_OPTS,
-                    "-Djavax.net.ssl.trustStore=/etc/ssl/theia-trust/truststore.jks -Djavax.net.ssl.trustStorePassword=changeit");
-            environmentVariables.put(PLACEHOLDER_TRUST_BUNDLE_MOUNT_PATH, "/etc/ssl/theia-trust");
-            environmentVariables.put(PLACEHOLDER_TRUST_BUNDLE_CONFIGMAP, "theia-internal-trust");
-        } else {
-            environmentVariables.put(PLACEHOLDER_CA_BUNDLE_PEM_PATH, "");
-            environmentVariables.put(PLACEHOLDER_GRADLE_TRUST_OPTS, "");
-            environmentVariables.put(PLACEHOLDER_TRUST_BUNDLE_MOUNT_PATH, "/tmp/trust-bundle-unused");
-            environmentVariables.put(PLACEHOLDER_TRUST_BUNDLE_CONFIGMAP, "trust-bundle-unused");
         }
 
         if (arguments.isEnableMonitor()) {

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateDeployment.yaml
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateDeployment.yaml
@@ -85,8 +85,8 @@ spec:
             value: placeholder-keycloak-env-clientid
           - name: BUILD_CACHE_ENABLED
             value: placeholder-build-cache-enabled
-          - name: GRADLE_BUILD_CACHE_URL
-            value: placeholder-gradle-build-cache-url
+          - name: BUILD_CACHE_URL
+            value: placeholder-build-cache-url
           - name: BAZEL_BUILD_CACHE_URL
             value: placeholder-bazel-build-cache-url
           - name: BUILD_CACHE_PUSH

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateDeployment.yaml
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateDeployment.yaml
@@ -85,8 +85,10 @@ spec:
             value: placeholder-keycloak-env-clientid
           - name: BUILD_CACHE_ENABLED
             value: placeholder-build-cache-enabled
-          - name: BUILD_CACHE_URL
-            value: placeholder-build-cache-url
+          - name: GRADLE_BUILD_CACHE_URL
+            value: placeholder-gradle-build-cache-url
+          - name: BAZEL_BUILD_CACHE_URL
+            value: placeholder-bazel-build-cache-url
           - name: BUILD_CACHE_PUSH
             value: placeholder-build-cache-push
           - name: DEPENDENCY_CACHE_ENABLED
@@ -101,14 +103,6 @@ spec:
             value: placeholder-data-bridge-strategy
           - name: THEIA
             value: 1
-          - name: NODE_EXTRA_CA_CERTS
-            value: placeholder-ca-bundle-pem-path
-          - name: GRADLE_OPTS
-            value: placeholder-gradle-trust-opts
-          volumeMounts:
-            - name: trust-bundle
-              mountPath: placeholder-trust-bundle-mount-path
-              readOnly: true
           securityContext:
             runAsUser: placeholder-uid
             runAsGroup: placeholder-uid
@@ -124,7 +118,3 @@ spec:
         - name: oauth2-emails
           configMap:
             name: placeholder-emailsconfigname
-        - name: trust-bundle
-          configMap:
-            name: placeholder-trust-bundle-configmap
-            optional: true

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateDeploymentWithoutOAuthProxy.yaml
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateDeploymentWithoutOAuthProxy.yaml
@@ -72,8 +72,10 @@ spec:
             value: placeholder-keycloak-env-clientid
           - name: BUILD_CACHE_ENABLED
             value: placeholder-build-cache-enabled
-          - name: BUILD_CACHE_URL
-            value: placeholder-build-cache-url
+          - name: GRADLE_BUILD_CACHE_URL
+            value: placeholder-gradle-build-cache-url
+          - name: BAZEL_BUILD_CACHE_URL
+            value: placeholder-bazel-build-cache-url
           - name: BUILD_CACHE_PUSH
             value: placeholder-build-cache-push
           - name: DEPENDENCY_CACHE_ENABLED
@@ -86,22 +88,9 @@ spec:
             value: placeholder-data-bridge-enabled
           - name: SCORPIO_THEIA_ENV_STRATEGY
             value: placeholder-data-bridge-strategy
-          - name: NODE_EXTRA_CA_CERTS
-            value: placeholder-ca-bundle-pem-path
-          - name: GRADLE_OPTS
-            value: placeholder-gradle-trust-opts
-          volumeMounts:
-            - name: trust-bundle
-              mountPath: placeholder-trust-bundle-mount-path
-              readOnly: true
-
           securityContext:
             runAsUser: placeholder-uid
             runAsGroup: placeholder-uid
       securityContext:
         fsGroup: placeholder-uid
       volumes:
-        - name: trust-bundle
-          configMap:
-            name: placeholder-trust-bundle-configmap
-            optional: true

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateDeploymentWithoutOAuthProxy.yaml
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateDeploymentWithoutOAuthProxy.yaml
@@ -72,8 +72,8 @@ spec:
             value: placeholder-keycloak-env-clientid
           - name: BUILD_CACHE_ENABLED
             value: placeholder-build-cache-enabled
-          - name: GRADLE_BUILD_CACHE_URL
-            value: placeholder-gradle-build-cache-url
+          - name: BUILD_CACHE_URL
+            value: placeholder-build-cache-url
           - name: BAZEL_BUILD_CACHE_URL
             value: placeholder-bazel-build-cache-url
           - name: BUILD_CACHE_PUSH
@@ -93,4 +93,3 @@ spec:
             runAsGroup: placeholder-uid
       securityContext:
         fsGroup: placeholder-uid
-      volumes:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Build cache handling split to support separate Gradle and Bazel cache URLs; validation now requires at least one configured cache.
  * Gradle cache option accepts a legacy alias for compatibility.
  * Removed TLS/trust-bundle configuration and related environment variables/mounts from deployment templates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EduIDE/EduIDE-Cloud/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->